### PR TITLE
fix: sort age category results by combinedCatRank, not global rank

### DIFF
--- a/race-combinator/canoe-race-combine.html
+++ b/race-combinator/canoe-race-combine.html
@@ -1282,6 +1282,13 @@
 
                 // Sort age categories
                 for (const catId in ageCategoriesResults) {
+                    ageCategoriesResults[catId].competitors.sort((a, b) => {
+                        if (a.combinedCatRank !== b.combinedCatRank) {
+                            return a.combinedCatRank - b.combinedCatRank;
+                        }
+                        return a.combinedTime - b.combinedTime;
+                    });
+
                     // Add ranking within category
                     ageCategoriesResults[catId].competitors.forEach((competitor, index) => {
                         competitor.categoryRank = index + 1;


### PR DESCRIPTION
## Summary

- Age category sub-tables inherited global competitor order (sorted by sum of overall ranks across all competitors) instead of sorting independently by sum of category ranks within the age group.
- When two competitors had the same `combinedCatRank`, the tiebreaker was effectively their global standing, not their combined time — producing wrong placements.
- Fix: sort each age category group by `combinedCatRank`, then `combinedTime`, before assigning `categoryRank`.

**Concrete case (K1W U14, Poříčanské slalomy):**

| Závodnice | ∑Rank (global) | ∑CatRank | ∑Čas | Pořadí před opravou | Pořadí po opravě |
|---|---|---|---|---|---|
| Křižková | 13 | 3 | 253.210 | 1. ❌ | 2. ✅ |
| Pišvejcová | 15 | 3 | 252.230 | 2. ❌ | 1. ✅ |

## Test plan

- [ ] Nahraj `2026_Podripske_slalomy_v1.xml` do kombinátoru (oba dny jako dva soubory, nebo jeden soubor se dvěma dny)
- [ ] Spáruj K1W den 13 + K1W den 14
- [ ] V tabulce věkové kategorie **K1 ženy U14** ověř, že Pišvejcová je 1. a Křižková 2.
- [ ] Ověř ostatní věkové kategorie — pořadí závodníků s různým `∑CatRnk` musí zůstat správné

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)