### PR TITLE
fix: show overall ranks in age category sub-tables (variant B)

### DIFF
--- a/race-combinator/canoe-race-combine.html
+++ b/race-combinator/canoe-race-combine.html
@@ -1471,11 +1471,11 @@
                                 <td>${competitor.name}</td>
                                 <td class="cell-numeric">${competitor.year || ''}</td>
                                 <td>${competitor.club || ''}</td>
-                                <td class="cell-numeric">${competitor.results[0].missing ? '999' : `${competitor.results[0].catRank}.`}</td>
+                                <td class="cell-numeric">${competitor.results[0].missing ? '999' : `${competitor.results[0].rank}.`}</td>
                                 <td class="cell-numeric">${competitor.results[0].timeFormatted}</td>
-                                <td class="cell-numeric">${competitor.results[1].missing ? '999' : `${competitor.results[1].catRank}.`}</td>
+                                <td class="cell-numeric">${competitor.results[1].missing ? '999' : `${competitor.results[1].rank}.`}</td>
                                 <td class="cell-numeric">${competitor.results[1].timeFormatted}</td>
-                                <td class="cell-numeric">${competitor.combinedCatRank}</td>
+                                <td class="cell-numeric">${competitor.combinedRank}</td>
                                 <td class="cell-numeric">${formatTime(competitor.combinedTime)}</td>
                             </tr>
                         `;


### PR DESCRIPTION
## Summary

Alternative fix for #3 — see also PR #4 for the independent-sort approach (variant A).

**Varianta B:** Tabulky věkových kategorií jsou filtrovaný pohled do globálního pořadí. Závodníci jsou seřazeni podle součtu celkových pořadí (jako v hlavní tabulce). Sloupce `1st #`, `2nd #` a `∑ #` nyní konzistentně zobrazují **celková** pořadí (`rank`, `combinedRank`) — nikoliv pořadí v rámci věkové skupiny.

Před opravou zobrazovaly tyto sloupce kategoriová pořadí (`catRank`, `combinedCatRank`), zatímco řazení tabulky bylo podle globálního pořadí — nesoulad, který způsoboval matoucí výstup (∑ # = 3 u obou závodnic, přesto jiné pořadí v tabulce).

**Konkrétní případ (K1W U14):**

| Závodnice | ∑Rank (global) | ∑CatRank | Zobrazený ∑ # před | Zobrazený ∑ # po |
|---|---|---|---|---|
| Křižková | **13** | 3 | 3 ⚠️ | **13** ✅ |
| Pišvejcová | **15** | 3 | 3 ⚠️ | **15** ✅ |

Pořadí v tabulce zůstává: Křižková 1., Pišvejcová 2. — a zobrazené ∑ # nyní toto pořadí vysvětluje.

## Změny

Pouze 3 řádky v `canoe-race-combine.html`, výhradně v renderu kategoriové tabulky:
- `catRank` → `rank` (sloupce 1st # a 2nd #)
- `combinedCatRank` → `combinedRank` (sloupec ∑ #)

## Test plan

- [ ] Nahraj `2026_Podripske_slalomy_v1.xml`, spáruj K1W den 13 + K1W den 14
- [ ] V tabulce **K1 ženy U14** ověř: Křižková 1. (∑ # = 13), Pišvejcová 2. (∑ # = 15)
- [ ] Ověř, že závodnice s různým `combinedRank` jsou správně seřazeny v ostatních věkových kategoriích
- [ ] Porovnej s PR #4 (varianta A) a rozhodněte, který model je záměrem

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)